### PR TITLE
chore: allow trivy low

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,3 +51,4 @@ jobs:
           VALIDATE_BIOME_LINT: false
           JAVASCRIPT_ES_CONFIG_FILE: ../../eslint.config.mjs
           TYPESCRIPT_ES_CONFIG_FILE: ../../eslint.config.mjs
+          TRIVY_SEVERITY: CRITICAL,HIGH,MEDIUM


### PR DESCRIPTION
- we have dependabot managing this if possible
- no need to block the pipelines on low severity vulns